### PR TITLE
Utilities for validating form and query input.

### DIFF
--- a/src/midas/params.gleam
+++ b/src/midas/params.gleam
@@ -1,10 +1,10 @@
 //// Handle untrusted input at your system boundaries.
 ////
-////    import midas/params
+////    import midas/params.{required, boolean, optional, as_string, as_integer, Trim, MinLength, MaxLength, Min}
 ////
-////    let name = required(form, "name", as_string(_, [MinLength(2), MaxLength(20)]))
+////    try name = required(form, "name", as_string(_, [Trim, MinLength(2), MaxLength(20)]))
 ////    let mailing_list = boolean(form, "mailing_list")
-////    let age = optional(form, "age", as_integer(_, [Min(0)]))
+////    try age = optional(form, "age", as_integer(_, [Min(0)]))
 ////
 //// This module works on lists of string pairs,
 //// as this data structure can represent data where the order is important or not.

--- a/src/midas/params.gleam
+++ b/src/midas/params.gleam
@@ -76,3 +76,25 @@ pub fn overridable(from form, get key, cast, or fallback) {
     Error(Missing(_key)) -> Ok(fallback)
   }
 }
+
+/// Returns true if the given key is present.
+///
+/// NOTE: This function is different to others in the module,
+/// an empty string associated with a given key will still return `True`.
+pub fn boolean(form, key) {
+  case list.key_find(form, key) {
+    Ok(_) -> True
+    Error(_) -> False
+  }
+}
+
+/// Check that a value is not present in the data.
+///
+/// Useful for indicating fields that might be provided but are unsupported.
+/// If there is a value for the key a `CastFailure` will be returned as the reason for the error.
+pub fn disallowed(from form, get key, reason) {
+  case find(form, key) {
+    Ok(raw) -> Error(CastFailure(key, reason))
+    Error(Missing(_key)) -> Ok(Nil)
+  }
+}

--- a/src/midas/params.gleam
+++ b/src/midas/params.gleam
@@ -1,0 +1,48 @@
+//// Handle untrusted input at your system boundaries.
+////
+//// This module works on lists of string pairs,
+//// as this data structure can represent data where the order is important or not.
+////
+//// ## Examples
+////
+////    let raw = map.to_list(os.get_env())
+////    let Ok(raw) = http.get_query(request)
+////    let Ok(raw) = http.get_form(request)
+////
+//// More complex data structures, such as JSON, cannot use these functions, yet.
+////
+//// ## Questions
+////
+//// - Is there a better name, e.g. spec
+////   `spec.required(params, "key", as_blah)`
+//// - Should the raw data structure be binaries not strings,
+////   Several functions can be parameterised but the as functions probably can't
+//// - Should we offer a pop version so that you can test for unused keys.
+
+import gleam/list
+import gleam/result
+
+/// Possible reasons for a field to be invalid.
+pub type Invalid(a) {
+  Missing(key: String)
+  CastFailure(key: String, help: a)
+}
+
+fn find(form, key) {
+  case list.key_find(form, key) {
+    // This one reference to an empty string makes it much less versatile, but in reality most inputs have string keys.
+    Ok("") -> Error(Missing(key))
+    Error(Nil) -> Error(Missing(key))
+    Ok(value) -> Ok(value)
+  }
+}
+
+/// Require a value for the associated key in the input data.
+///
+/// A value of an empty string `""` is also considered a missing value.
+/// Check `boolean` for testing just the presence of a field.
+pub fn required(from form, get key, cast) {
+  try raw = find(form, key)
+  cast(raw)
+  |> result.map_error(CastFailure(key, _))
+}

--- a/src/midas/params.gleam
+++ b/src/midas/params.gleam
@@ -1,5 +1,11 @@
 //// Handle untrusted input at your system boundaries.
 ////
+////    import midas/params
+////
+////    let name = required(form, "name", as_string(_, [MinLength(2), MaxLength(20)]))
+////    let mailing_list = boolean(form, "mailing_list")
+////    let age = optional(form, "age", as_integer(_, [Min(0)]))
+////
 //// This module works on lists of string pairs,
 //// as this data structure can represent data where the order is important or not.
 ////
@@ -18,6 +24,11 @@
 //// - Should the raw data structure be binaries not strings,
 ////   Several functions can be parameterised but the as functions probably can't
 //// - Should we offer a pop version so that you can test for unused keys.
+//// - Should there be more built in type validators.
+////   - as_iso8601_data
+////   - as_iso8601_datatime
+////   - as_email
+////   - as_url absolute, secure(true, false), local(true false)
 
 import gleam/int
 import gleam/list
@@ -151,6 +162,9 @@ pub fn as_string(raw, validations) {
 }
 
 // should be possible to reuse for floats
+/// Validation rules that may be applied to integers.
+///
+/// Rules are applied in order
 pub type NumberValidations {
   Min(Int)
   Max(Int)
@@ -181,6 +195,7 @@ fn run_number_validations(number, validations) {
   }
 }
 
+/// Cast an input value as an integer that obeys the given validation rules
 pub fn as_integer(raw, validations) {
   case int.parse(string.trim(raw)) {
     Ok(number) -> run_number_validations(number, validations)

--- a/test/midas/params_test.gleam
+++ b/test/midas/params_test.gleam
@@ -55,3 +55,31 @@ pub fn overridable_param_test() {
   |> params.overridable("foo", fn(_) { Error("not a foo") }, "baz")
   |> should.equal(Error(CastFailure("foo", "not a foo")))
 }
+
+pub fn boolean_param_test() {
+  []
+  |> params.boolean("foo")
+  |> should.equal(False)
+
+  [tuple("foo", "")]
+  |> params.boolean("foo")
+  |> should.equal(True)
+
+  [tuple("foo", "bar")]
+  |> params.boolean("foo")
+  |> should.equal(True)
+}
+
+pub fn disallowed_param_test() {
+  []
+  |> params.disallowed("foo", "unsupported")
+  |> should.equal(Ok(Nil))
+
+  [tuple("foo", "")]
+  |> params.disallowed("foo", "unsupported")
+  |> should.equal(Ok(Nil))
+
+  [tuple("foo", "bar")]
+  |> params.disallowed("foo", "unsupported")
+  |> should.equal(Error(CastFailure("foo", "unsupported")))
+}

--- a/test/midas/params_test.gleam
+++ b/test/midas/params_test.gleam
@@ -1,0 +1,20 @@
+import midas/params.{Missing, CastFailure}
+import gleam/should
+
+pub fn required_param_test() {
+  []
+  |> params.required("foo", Ok)
+  |> should.equal(Error(Missing("foo")))
+
+  [tuple("foo", "")]
+  |> params.required("foo", Ok)
+  |> should.equal(Error(Missing("foo")))
+
+  [tuple("foo", "value")]
+  |> params.required("foo", Ok)
+  |> should.equal(Ok("value"))
+
+  [tuple("foo", "value")]
+  |> params.required("foo", fn(_) { Error("not a foo") })
+  |> should.equal(Error(CastFailure("foo", "not a foo")))
+}

--- a/test/midas/params_test.gleam
+++ b/test/midas/params_test.gleam
@@ -1,3 +1,4 @@
+import gleam/option.{Some, None}
 import midas/params.{Missing, CastFailure}
 import gleam/should
 
@@ -10,11 +11,47 @@ pub fn required_param_test() {
   |> params.required("foo", Ok)
   |> should.equal(Error(Missing("foo")))
 
-  [tuple("foo", "value")]
+  [tuple("foo", "bar")]
   |> params.required("foo", Ok)
-  |> should.equal(Ok("value"))
+  |> should.equal(Ok("bar"))
 
-  [tuple("foo", "value")]
+  [tuple("foo", "bar")]
   |> params.required("foo", fn(_) { Error("not a foo") })
+  |> should.equal(Error(CastFailure("foo", "not a foo")))
+}
+
+pub fn optional_param_test() {
+  []
+  |> params.optional("foo", Ok)
+  |> should.equal(Ok(None))
+
+  [tuple("foo", "")]
+  |> params.optional("foo", Ok)
+  |> should.equal(Ok(None))
+
+  [tuple("foo", "bar")]
+  |> params.optional("foo", Ok)
+  |> should.equal(Ok(Some("bar")))
+
+  [tuple("foo", "bar")]
+  |> params.optional("foo", fn(_) { Error("not a foo") })
+  |> should.equal(Error(CastFailure("foo", "not a foo")))
+}
+
+pub fn overridable_param_test() {
+  []
+  |> params.overridable("foo", Ok, "baz")
+  |> should.equal(Ok("baz"))
+
+  [tuple("foo", "")]
+  |> params.overridable("foo", Ok, "baz")
+  |> should.equal(Ok("baz"))
+
+  [tuple("foo", "bar")]
+  |> params.overridable("foo", Ok, "baz")
+  |> should.equal(Ok("bar"))
+
+  [tuple("foo", "bar")]
+  |> params.overridable("foo", fn(_) { Error("not a foo") }, "baz")
   |> should.equal(Error(CastFailure("foo", "not a foo")))
 }


### PR DESCRIPTION
 Handle untrusted input at your system boundaries.

    import midas/params.{required, boolean, optional, as_string, as_integer, MinLength, MaxLength}

    try name = required(form, "name", as_string(_, [MinLength(2), MaxLength(20)]))
    let mailing_list = boolean(form, "mailing_list")
    try age = optional(form, "age", as_integer(_, [Min(0)]))

 This module works on lists of string pairs,
 as this data structure can represent data where the order is important or not.

 ## Examples

    let raw = map.to_list(os.get_env())
    let Ok(raw) = http.get_query(request)
    let Ok(raw) = http.get_form(request)

 More complex data structures, such as JSON, cannot use these functions, yet.

 ## Questions

 - Is there a better name, e.g. spec
   `spec.required(params, "key", as_blah)`
 - Should the raw data structure be binaries not strings,
   Several functions can be parameterised but the as functions probably can't
 - Should we offer a pop version so that you can test for unused keys.
 - Should there be more built in type validators.
   - as_iso8601_data
   - as_iso8601_datatime
   - as_email
   - as_url absolute, secure(true, false), local(true false)


## Notes 
This tackles #14, there are more details there about further integration with general error handling.
This current library only shows one error at a time. Are these useful tools to build a form validation library that would handle multiple errors at a time.
 
